### PR TITLE
fix: fix login not working in prod

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -10,7 +10,7 @@ export const environment = {
     appId: '1:494567369272:web:cf93d3b00d0f383da354cd'
   },
   actionCodeSettings: {
-    url: 'https://firebridge-7ba35.web.app/login',
+    url: 'https://firebridge-7ba35.web.app/',
     handleCodeInApp: true
   }
 };


### PR DESCRIPTION
Issue was due to an outdated redirect uri. `/login` does not have an `AuthGuard`, so redirecting to `/login` does not trigger the guard, which is required to complete authentication.

Closes #13 