### PR TITLE
refactor: move the tournament collection under a user document

### DIFF
--- a/src/app/tournament/tournament.service.ts
+++ b/src/app/tournament/tournament.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AngularFirestore, DocumentReference } from '@angular/fire/firestore';
+import { AngularFirestore, AngularFirestoreCollection, DocumentReference } from '@angular/fire/firestore';
 
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -12,14 +12,14 @@ import { Tournament, TournamentData } from './tournament';
 })
 export class TournamentService {
 
-  constructor(private authService: AuthService, private ngFirestore: AngularFirestore) { }
+  private collection: AngularFirestoreCollection<TournamentData>;
+
+  constructor(private ngFirestore: AngularFirestore, authService: AuthService) {
+    this.collection = ngFirestore.collection('directors').doc(authService.principal.uid).collection('tournaments');
+  }
 
   findAllByOwner(): Observable<Tournament[]> {
-    const ownerId = this.authService.principal.uid;
-    const query = ref => ref.where('ownerId', '==', ownerId);
-    const resultSet = this.ngFirestore.collection<TournamentData>('tournaments', query);
-
-    return resultSet.snapshotChanges().pipe(
+    return this.collection.snapshotChanges().pipe(
       map(changes =>
         changes.map(change => {
           const id = change.payload.doc.id;
@@ -32,15 +32,14 @@ export class TournamentService {
   }
 
   create(tournamentData: TournamentData): Promise<DocumentReference> {
-    tournamentData.ownerId = this.authService.principal.uid;
-    return this.ngFirestore.collection('tournaments').add(tournamentData);
+    return this.collection.add(tournamentData);
   }
 
   update(tournament: Tournament): Promise<void> {
-    return this.ngFirestore.collection(`tournaments`).doc(tournament.id).set(tournament.data);
+    return this.collection.doc(tournament.id).set(tournament.data);
   }
 
   delete(tournamentId: string): Promise<void> {
-    return this.ngFirestore.collection(`tournaments`).doc(tournamentId).delete();
+    return this.collection.doc(tournamentId).delete();
   }
 }

--- a/src/app/tournament/tournament.ts
+++ b/src/app/tournament/tournament.ts
@@ -7,7 +7,6 @@ export interface Tournament {
 }
 
 export interface TournamentData {
-  ownerId: string;
   name: string;
   date: Timestamp;
   assignedRaspberryPis: [{


### PR DESCRIPTION
This is done to simplify Security Rules by applying the "content-owner only access" pattern.

Closes #35 